### PR TITLE
Completed `get_spm_globals` function

### DIFF
--- a/spm_funcs.py
+++ b/spm_funcs.py
@@ -54,8 +54,9 @@ def get_spm_globals(fname):
     spm_vals : array
         SPM global metric for each 3D volume in the 4D image.
     """
-    # +++your code here+++
-    # return
+    data = nib.load(fname).get_fdata()
+    spm_global_metric = [spm_global(data[..., i]) for i in range(data.shape[-1])]
+    return np.array(spm_global_metric)
 
 
 def main():


### PR DESCRIPTION
This PR completes the body of `get_spm_globals` from `spm_funcs.py`. 

`get_spm_globals` loads a 3D+t NIfTI image from a given path and returns the SPM global metric as a numpy array.